### PR TITLE
Add type hints to /map endpoint query params

### DIFF
--- a/src/hdf5_reader_service/api.py
+++ b/src/hdf5_reader_service/api.py
@@ -71,7 +71,7 @@ def get_tree(path: str, subpath: str = "/") -> JSONResponse:
 
 
 @router.get("/map")
-def get_map(filepath, datapath, snake) -> JSONResponse:
+def get_map(filepath: str, datapath: str, snake: bool = False) -> JSONResponse:
     r = fork_and_do(fetch_map, args=(filepath, datapath, snake, SWMR_DEFAULT))
     return NumpySafeJSONResponse(r)
 


### PR DESCRIPTION
Without which the snake param is taken as a string, resulting in snake always being True. Fixed, and additionally defaulted snake to False.